### PR TITLE
fix: trim the product_serial for the hostname

### DIFF
--- a/overlay/files/system/oem/00_datasources.yaml
+++ b/overlay/files/system/oem/00_datasources.yaml
@@ -9,6 +9,17 @@ stages:
           slugify() {
               echo "$1" | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-' | sed 's/[^[:alnum:]]\{1,\}/-/g' | sed 's/^-//;s/-$//'
           }
+          
+          truncate_string() {
+            input_string=$1
+            str_length=$(expr length "$input_string")
+            if [ "$str_length" -gt 32 ]; then
+              start_pos=$(expr $str_length - 31)
+              echo $(expr substr "$input_string" $start_pos 32)
+            else
+              echo "$input_string"
+            fi
+          }
 
           try_fetch_metadata() {
               provider=$1
@@ -92,12 +103,11 @@ stages:
               product_serial=$(cat /sys/class/dmi/id/product_serial)
               slugified_sys_vendor=$(slugify "${sys_vendor}")
               slugified_product_serial=$(slugify "${product_serial}")
-              instance_hostname="${slugified_sys_vendor}-${slugified_product_serial}"
+              truncated_product_serial=$(truncate_string "${slugified_product_serial}")
+              instance_hostname="${slugified_sys_vendor}-${truncated_product_serial}"
               echo "Instance Hostname: ${instance_hostname}"
               echo "${instance_hostname}" > /etc/hostname
           fi
-
-          # The script will fail silently if the URL is unreachable or user_data/instance_hostname is empty/null
     - name: "Process data from provider"
       datasource:
         providers: ["cdrom", "file"]


### PR DESCRIPTION
This keeps the serial number portion of hardware-defined hostnames to within 32 characters