### PR TITLE
feat: add digital ocean support for pulling cloud metadata

### DIFF
--- a/overlay/files/system/oem/00_datasources.yaml
+++ b/overlay/files/system/oem/00_datasources.yaml
@@ -45,6 +45,10 @@ stages:
                       user_data_path="/user_data"
                       hostname_path="/meta_data.json"
                       ;;
+                  digitalocean)
+                      metadata_url="http://169.254.169.254/metadata/v1"
+                      user_data_path="/user_data"
+                      hostname_path="/hostname"
               esac
 
               # Test the request to the metadata URL
@@ -57,7 +61,7 @@ stages:
               return $?
           }
 
-          for provider in oracle aws gcp openstack none; do
+          for provider in oracle aws gcp openstack digitalocean none; do
               if [ "$provider" = "none" ]; then
                   break
               fi


### PR DESCRIPTION
While DO supports a cdrom-style injection for cloud-init data, this
 simple change enables us to pull the user-data scripts and the hostname
 directly from the metadata api. This spares us the complexity of having to
 find and mount the cdrom drive since we aren't using official cloud-init that
 would scan and identify the metadata cdrom for us.
